### PR TITLE
Add deck builder and integrate dungeon GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository contains a prototype for a card-based RPG duel engine written in
 - Tkinter-based start menu and GUI.
 - Simple "Dungeon Battle" mode that displays placeholder sprites for a 1v1
   encounter.
+- Deck building menu to select a character and construct a 20 card deck
+  (maximum two copies of each card).
 
 ## Running the Demo
 

--- a/battle/dungeon_gui.py
+++ b/battle/dungeon_gui.py
@@ -1,83 +1,33 @@
 import tkinter as tk
 from PIL import Image, ImageDraw, ImageTk
-from tkinter import messagebox
+from .gui import BattleGUI
 
 
-class DungeonBattleGUI:
-    """Simple 1v1 battle view with placeholder sprites."""
+class DungeonBattleGUI(BattleGUI):
+    """BattleGUI variant that displays simple sprites on a canvas."""
 
     def _make_sprite(self, color: str, letter: str) -> Image:
-        """Create a simple square sprite of a given color with a single letter."""
         img = Image.new("RGBA", (60, 60), color)
         draw = ImageDraw.Draw(img)
         draw.text((20, 20), letter, fill="white")
         return img
 
     def __init__(self, player, enemy):
-        self.player = player
-        self.enemy = enemy
-        self.root = tk.Tk()
+        super().__init__(player, enemy)
         self.root.title("Dungeon Battle")
 
-        # Canvas for drawing sprites and effects
         self.canvas = tk.Canvas(self.root, width=400, height=300, bg="black")
-        self.canvas.pack(fill="both", expand=True)
+        self.canvas.pack(before=self.log_text, fill="both", expand=True)
 
-        # Create simple placeholder sprites in memory
         self.player_img = ImageTk.PhotoImage(self._make_sprite("blue", "P"))
         self.enemy_img = ImageTk.PhotoImage(self._make_sprite("red", "E"))
-
-        # Status labels
-        self.info = tk.Label(self.root, text="")
-        self.info.pack()
-
-        # Action buttons
-        self.btn_frame = tk.Frame(self.root)
-        self.btn_frame.pack(fill="x")
-        self.attack_btn = tk.Button(self.btn_frame, text="Attack", command=self.attack)
-        self.attack_btn.pack(side="left", expand=True, fill="x")
-        self.flee_btn = tk.Button(self.btn_frame, text="Flee", command=self.flee)
-        self.flee_btn.pack(side="left", expand=True, fill="x")
-
         self.redraw()
 
     def redraw(self):
         self.canvas.delete("all")
-        # player in foreground left-bottom
         self.canvas.create_image(100, 220, image=self.player_img)
-        # enemy in background right-top
         self.canvas.create_image(300, 80, image=self.enemy_img)
-        # update stats
-        text = f"{self.player.name} HP:{self.player.hp}/{self.player.max_hp}  VS  {self.enemy.name} HP:{self.enemy.hp}/{self.enemy.max_hp}"
-        self.info.config(text=text)
 
-    def attack(self):
-        # simple effect: flash rectangle on enemy
-        rect = self.canvas.create_rectangle(260, 40, 340, 120, fill="yellow")
-        self.canvas.after(200, lambda: self.canvas.delete(rect))
-        self.enemy.hp -= 3
-        if self.enemy.hp <= 0:
-            messagebox.showinfo("Victory", "Enemy defeated!")
-            self.player.gain_xp(20)
-            self.root.quit()
-        else:
-            self.root.after(300, self.enemy_attack)
+    def update_labels(self):
+        super().update_labels()
         self.redraw()
-
-    def enemy_attack(self):
-        rect = self.canvas.create_rectangle(60, 180, 140, 260, fill="red")
-        self.canvas.after(200, lambda: self.canvas.delete(rect))
-        self.player.hp -= 2
-        if self.player.hp <= 0:
-            messagebox.showinfo("Defeat", "You were defeated!")
-            self.root.quit()
-        self.redraw()
-
-    def flee(self):
-        messagebox.showinfo("Flee", "You fled the battle!")
-        self.root.quit()
-
-    def start(self):
-        self.player.refill_hand()
-        self.enemy.refill_hand()
-        self.root.mainloop()

--- a/deck_builder.py
+++ b/deck_builder.py
@@ -1,0 +1,86 @@
+import tkinter as tk
+from battle.engine import create_basic_cards
+from characters import Character
+from items import create_basic_items
+from cards import Card
+
+
+def run_deck_builder_menu():
+    """Interactive menu for selecting a character and building a 20 card deck."""
+    characters = {
+        "Wizard": dict(hp=25, mana=15, stamina=8),
+        "Warrior": dict(hp=35, mana=5, stamina=15),
+        "Rogue": dict(hp=28, mana=10, stamina=12),
+    }
+    card_prototypes = create_basic_cards()
+
+    root = tk.Tk()
+    root.title("Deck Builder")
+
+    selected_character = tk.StringVar(value=list(characters.keys())[0])
+    deck = []
+    card_counts = {c.name: 0 for c in card_prototypes}
+
+    # --- Character selection --------------------------------------------
+    char_frame = tk.Frame(root)
+    char_frame.pack(padx=10, pady=5, fill="x")
+    tk.Label(char_frame, text="Choose Character:").pack(anchor="w")
+    for name in characters:
+        tk.Radiobutton(char_frame, text=name, variable=selected_character,
+                       value=name).pack(anchor="w")
+
+    # --- Card selection --------------------------------------------------
+    card_frame = tk.Frame(root)
+    card_frame.pack(padx=10, pady=5)
+    tk.Label(card_frame, text="Build Deck (max 2 of each card)").pack()
+
+    count_vars = {}
+
+    def update_labels():
+        deck_label.config(text=f"Deck size: {len(deck)}/20")
+        for name, var in count_vars.items():
+            var.set(str(card_counts[name]))
+
+    def add_card(card):
+        if card_counts[card.name] >= 2 or len(deck) >= 20:
+            return
+        card_counts[card.name] += 1
+        deck.append(Card(card.name, card.cost, card.resource_type,
+                         card.effect_function, card.description))
+        update_labels()
+
+    def remove_card(card):
+        if card_counts[card.name] <= 0:
+            return
+        card_counts[card.name] -= 1
+        for i, c in enumerate(deck):
+            if c.name == card.name:
+                deck.pop(i)
+                break
+        update_labels()
+
+    for c in card_prototypes:
+        row = tk.Frame(card_frame)
+        row.pack(fill="x", pady=2)
+        tk.Label(row, text=f"{c.name} ({c.cost} {c.resource_type})").pack(side="left")
+        count_var = tk.StringVar(value="0")
+        count_vars[c.name] = count_var
+        tk.Label(row, textvariable=count_var, width=3).pack(side="left")
+        tk.Button(row, text="+", command=lambda card=c: add_card(card)).pack(side="left")
+        tk.Button(row, text="-", command=lambda card=c: remove_card(card)).pack(side="left")
+
+    deck_label = tk.Label(root, text="Deck size: 0/20")
+    deck_label.pack(pady=5)
+
+    def finish():
+        if len(deck) == 20:
+            root.quit()
+
+    tk.Button(root, text="Start Game", command=finish).pack(pady=5)
+    root.mainloop()
+    root.destroy()
+
+    stats = characters[selected_character.get()]
+    return Character(name=selected_character.get(),
+                     hp=stats["hp"], mana=stats["mana"], stamina=stats["stamina"],
+                     deck=deck, items=create_basic_items()[:2])

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from battle.engine import create_basic_cards, run_battle
 from battle.gui import BattleGUI
 from battle.dungeon_gui import DungeonBattleGUI
+from deck_builder import run_deck_builder_menu
 from start_menu import run_start_menu
 from characters import Character
 from items import create_basic_items
@@ -18,7 +19,7 @@ def main():
         print("Exited from start menu.")
         return
 
-    player = build_sample_character("Player")
+    player = run_deck_builder_menu()
     enemy = build_sample_character("Enemy")
 
     if mode == "gui":


### PR DESCRIPTION
## Summary
- add a Tkinter-based deck building menu for selecting a character and 20-card deck
- combine GUI battle controls with dungeon battle by subclassing `BattleGUI`
- hook deck builder into game startup
- document deck builder in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile *.py battle/*.py characters/*.py cards/*.py deck_builder.py`
- `python - <<'PY'
import deck_builder
print('starting deck builder test - will quit immediately')
print(hasattr(deck_builder, 'run_deck_builder_menu'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684baf891eb08323b83b059764397aa6