### PR TITLE
Add bestiary and card library viewers

### DIFF
--- a/bestiary_viewer.py
+++ b/bestiary_viewer.py
@@ -1,0 +1,29 @@
+import tkinter as tk
+from bestiary import BESTIARY
+
+
+def show_bestiary():
+    """Display all bestiary entries in a scrollable window."""
+    root = tk.Tk()
+    root.title("Bestiary")
+
+    text = tk.Text(root, wrap="word", width=60)
+    scrollbar = tk.Scrollbar(root, command=text.yview)
+    text.configure(yscrollcommand=scrollbar.set)
+    text.pack(side="left", fill="both", expand=True)
+    scrollbar.pack(side="right", fill="y")
+
+    for monster in BESTIARY:
+        entry = f"{monster['name']}\n{monster['description']}\n" \
+                f"HP:{monster['hp']} DMG:{monster['damage']}\n" \
+                f"STR:{monster['str']} THAU:{monster['thaumaturgy']} " \
+                f"AGI:{monster['agi']} RES:{monster['res']}\n" \
+                f"Tactics: {monster['tactics']}\n\n"
+        text.insert("end", entry)
+
+    tk.Button(root, text="Close", command=root.destroy).pack(pady=5)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    show_bestiary()

--- a/card_library_viewer.py
+++ b/card_library_viewer.py
@@ -1,0 +1,34 @@
+import tkinter as tk
+from character_cards import CHARACTER_CARDS, UNIVERSAL_CARDS
+
+
+def show_card_library():
+    """Display all cards in the library in a scrollable window."""
+    root = tk.Tk()
+    root.title("Card Library")
+
+    text = tk.Text(root, wrap="word", width=60)
+    scrollbar = tk.Scrollbar(root, command=text.yview)
+    text.configure(yscrollcommand=scrollbar.set)
+    text.pack(side="left", fill="both", expand=True)
+    scrollbar.pack(side="right", fill="y")
+
+    text.insert("end", "Universal Cards\n")
+    for card in UNIVERSAL_CARDS:
+        entry = f"- {card['name']} ({card['type']}, cost {card['cost']} {card['resource']})\n  {card['effect']}\n"
+        text.insert("end", entry)
+    text.insert("end", "\n")
+
+    for name, data in CHARACTER_CARDS.items():
+        text.insert("end", f"{name} - {data['class']}\n")
+        for card in data['cards']:
+            entry = f"- {card['name']} ({card['type']}, cost {card['cost']} {card['resource']})\n  {card['effect']}\n"
+            text.insert("end", entry)
+        text.insert("end", "\n")
+
+    tk.Button(root, text="Close", command=root.destroy).pack(pady=5)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    show_card_library()

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ from deck_builder import run_deck_builder_menu
 from start_menu import run_start_menu
 from characters import Character
 from items import create_basic_items
+from bestiary_viewer import show_bestiary
+from card_library_viewer import show_card_library
 
 
 def build_sample_character(name):
@@ -14,20 +16,27 @@ def build_sample_character(name):
 
 
 def main():
+    player = None
     mode = run_start_menu()
-    if not mode:
-        print("Exited from start menu.")
-        return
+    while mode:
+        if mode == "deckbuilder":
+            player = run_deck_builder_menu()
+        elif mode == "bestiary":
+            show_bestiary()
+        elif mode == "library":
+            show_card_library()
+        else:
+            if player is None:
+                player = run_deck_builder_menu()
+            enemy = build_sample_character("Enemy")
+            if mode == "gui":
+                BattleGUI(player, enemy).start()
+            elif mode == "dungeon":
+                DungeonBattleGUI(player, enemy).start()
+            else:
+                run_battle(player, enemy)
 
-    player = run_deck_builder_menu()
-    enemy = build_sample_character("Enemy")
-
-    if mode == "gui":
-        BattleGUI(player, enemy).start()
-    elif mode == "dungeon":
-        DungeonBattleGUI(player, enemy).start()
-    else:
-        run_battle(player, enemy)
+        mode = run_start_menu()
 
 
 if __name__ == "__main__":

--- a/start_menu.py
+++ b/start_menu.py
@@ -4,9 +4,14 @@ import tkinter as tk
 def run_start_menu():
     """Display a menu for choosing the game mode.
 
-    Returns "console" for the text battle, "gui" for the graphical battle,
-    "dungeon" for the placeholder dungeon crawler, or ``None`` if the user
-    closes the menu without making a choice.
+    Returns one of:
+    ``"console"`` for the text battle,
+    ``"gui"`` for the graphical battle,
+    ``"dungeon"`` for the dungeon crawler,
+    ``"deckbuilder"`` to launch the deck builder,
+    ``"bestiary"`` to view the bestiary,
+    ``"library"`` to view the card library,
+    or ``None`` if the user closes the menu without making a choice.
     """
     selection = {"mode": None}
 
@@ -22,6 +27,18 @@ def run_start_menu():
         selection["mode"] = "dungeon"
         root.quit()
 
+    def choose_deckbuilder():
+        selection["mode"] = "deckbuilder"
+        root.quit()
+
+    def choose_bestiary():
+        selection["mode"] = "bestiary"
+        root.quit()
+
+    def choose_library():
+        selection["mode"] = "library"
+        root.quit()
+
     def exit_game():
         root.quit()
 
@@ -33,6 +50,9 @@ def run_start_menu():
     tk.Button(root, text="Console Battle", width=20, command=choose_console).pack(pady=5)
     tk.Button(root, text="GUI Battle", width=20, command=choose_gui).pack(pady=5)
     tk.Button(root, text="Dungeon Battle", width=20, command=choose_dungeon).pack(pady=5)
+    tk.Button(root, text="Deck Builder", width=20, command=choose_deckbuilder).pack(pady=5)
+    tk.Button(root, text="Bestiary", width=20, command=choose_bestiary).pack(pady=5)
+    tk.Button(root, text="Card Library", width=20, command=choose_library).pack(pady=5)
     tk.Button(root, text="Quit", width=20, command=exit_game).pack(pady=5)
 
     root.mainloop()


### PR DESCRIPTION
## Summary
- extend start menu with Deck Builder, Bestiary and Card Library options
- create `bestiary_viewer` for viewing monsters
- create `card_library_viewer` for viewing all cards
- loop main menu so you can pick actions repeatedly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bbe48169c8323ad87b9cd892b545f