### PR TITLE
Improve menus and combat flow

### DIFF
--- a/battle/gui.py
+++ b/battle/gui.py
@@ -121,8 +121,7 @@ class BattleGUI:
             self.player.gain_xp(50)
             self.root.quit()
             return
-        # Keep player's turn active
-        self.show_hand()
+        self.end_player_turn()
 
     def use_item(self, index):
         if not self.player.use_item(index):
@@ -135,6 +134,13 @@ class BattleGUI:
     def enemy_turn(self):
         self.enemy.update_effects()
         self.enemy.regenerate()
+        if self.enemy.is_defeated():
+            self.update_labels()
+            self.log("You won the battle!")
+            messagebox.showinfo("Victory", "You won the battle!")
+            self.player.gain_xp(50)
+            self.root.quit()
+            return
         if not self.enemy.hand:
             self.enemy.refill_hand()
         if self.enemy.hand:
@@ -160,6 +166,12 @@ class BattleGUI:
         self.clear_action_frame()
         self.player.update_effects()
         self.player.regenerate()
+        if self.player.is_defeated():
+            self.update_labels()
+            self.log("You lost the battle!")
+            messagebox.showinfo("Defeat", "You lost the battle!")
+            self.root.quit()
+            return
         self.update_labels()
         
     def start(self):

--- a/bestiary_viewer.py
+++ b/bestiary_viewer.py
@@ -2,24 +2,50 @@ import tkinter as tk
 from bestiary import BESTIARY
 
 
+def _show_monster(monster, parent):
+    """Display a pop-up window with the monster's details."""
+    win = tk.Toplevel(parent)
+    win.title(monster["name"])
+
+    text = tk.Text(win, wrap="word", width=60, height=15)
+    text.pack(fill="both", expand=True)
+
+    entry = (
+        f"{monster['name']}\n{monster['description']}\n"
+        f"HP:{monster['hp']} DMG:{monster['damage']}\n"
+        f"STR:{monster['str']} THAU:{monster['thaumaturgy']} "
+        f"AGI:{monster['agi']} RES:{monster['res']}\n"
+        f"Tactics: {monster['tactics']}"
+    )
+    text.insert("end", entry)
+    text.configure(state="disabled")
+
+    tk.Button(win, text="Close", command=win.destroy).pack(pady=5)
+
+
 def show_bestiary():
-    """Display all bestiary entries in a scrollable window."""
+    """Display bestiary entries as a clickable list of names."""
     root = tk.Tk()
     root.title("Bestiary")
 
-    text = tk.Text(root, wrap="word", width=60)
-    scrollbar = tk.Scrollbar(root, command=text.yview)
-    text.configure(yscrollcommand=scrollbar.set)
-    text.pack(side="left", fill="both", expand=True)
+    frame = tk.Frame(root)
+    frame.pack(fill="both", expand=True)
+
+    listbox = tk.Listbox(frame)
+    scrollbar = tk.Scrollbar(frame, orient="vertical", command=listbox.yview)
+    listbox.configure(yscrollcommand=scrollbar.set)
+    listbox.pack(side="left", fill="both", expand=True)
     scrollbar.pack(side="right", fill="y")
 
     for monster in BESTIARY:
-        entry = f"{monster['name']}\n{monster['description']}\n" \
-                f"HP:{monster['hp']} DMG:{monster['damage']}\n" \
-                f"STR:{monster['str']} THAU:{monster['thaumaturgy']} " \
-                f"AGI:{monster['agi']} RES:{monster['res']}\n" \
-                f"Tactics: {monster['tactics']}\n\n"
-        text.insert("end", entry)
+        listbox.insert("end", monster["name"])
+
+    def on_select(event):
+        idxs = listbox.curselection()
+        if idxs:
+            _show_monster(BESTIARY[idxs[0]], root)
+
+    listbox.bind("<Double-Button-1>", on_select)
 
     tk.Button(root, text="Close", command=root.destroy).pack(pady=5)
     root.mainloop()

--- a/card_library_viewer.py
+++ b/card_library_viewer.py
@@ -2,29 +2,55 @@ import tkinter as tk
 from character_cards import CHARACTER_CARDS, UNIVERSAL_CARDS
 
 
+def _show_card(card, parent):
+    """Display details for a single card."""
+    win = tk.Toplevel(parent)
+    win.title(card["name"])
+
+    text = tk.Text(win, wrap="word", width=60, height=10)
+    text.pack(fill="both", expand=True)
+
+    entry = (
+        f"{card['name']} ({card['type']}, cost {card['cost']} {card['resource']})\n"
+        f"{card['effect']}"
+    )
+    text.insert("end", entry)
+    text.configure(state="disabled")
+
+    tk.Button(win, text="Close", command=win.destroy).pack(pady=5)
+
+
 def show_card_library():
-    """Display all cards in the library in a scrollable window."""
+    """Display all card names in a scrollable list."""
     root = tk.Tk()
     root.title("Card Library")
 
-    text = tk.Text(root, wrap="word", width=60)
-    scrollbar = tk.Scrollbar(root, command=text.yview)
-    text.configure(yscrollcommand=scrollbar.set)
-    text.pack(side="left", fill="both", expand=True)
+    frame = tk.Frame(root)
+    frame.pack(fill="both", expand=True)
+
+    listbox = tk.Listbox(frame)
+    scrollbar = tk.Scrollbar(frame, orient="vertical", command=listbox.yview)
+    listbox.configure(yscrollcommand=scrollbar.set)
+    listbox.pack(side="left", fill="both", expand=True)
     scrollbar.pack(side="right", fill="y")
 
-    text.insert("end", "Universal Cards\n")
+    all_cards = []
     for card in UNIVERSAL_CARDS:
-        entry = f"- {card['name']} ({card['type']}, cost {card['cost']} {card['resource']})\n  {card['effect']}\n"
-        text.insert("end", entry)
-    text.insert("end", "\n")
+        all_cards.append(card)
+        listbox.insert("end", card["name"])
 
     for name, data in CHARACTER_CARDS.items():
-        text.insert("end", f"{name} - {data['class']}\n")
-        for card in data['cards']:
-            entry = f"- {card['name']} ({card['type']}, cost {card['cost']} {card['resource']})\n  {card['effect']}\n"
-            text.insert("end", entry)
-        text.insert("end", "\n")
+        for card in data["cards"]:
+            label = f"{card['name']} ({name})"
+            all_cards.append(card)
+            listbox.insert("end", label)
+
+    def on_select(event):
+        idxs = listbox.curselection()
+        if idxs:
+            _show_card(all_cards[idxs[0]], root)
+
+    listbox.bind("<Double-Button-1>", on_select)
 
     tk.Button(root, text="Close", command=root.destroy).pack(pady=5)
     root.mainloop()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 from battle.engine import create_basic_cards, run_battle
-from battle.gui import BattleGUI
 from battle.dungeon_gui import DungeonBattleGUI
 from deck_builder import run_deck_builder_menu
 from start_menu import run_start_menu
@@ -29,9 +28,7 @@ def main():
             if player is None:
                 player = run_deck_builder_menu()
             enemy = build_sample_character("Enemy")
-            if mode == "gui":
-                BattleGUI(player, enemy).start()
-            elif mode == "dungeon":
+            if mode == "dungeon":
                 DungeonBattleGUI(player, enemy).start()
             else:
                 run_battle(player, enemy)

--- a/start_menu.py
+++ b/start_menu.py
@@ -5,8 +5,6 @@ def run_start_menu():
     """Display a menu for choosing the game mode.
 
     Returns one of:
-    ``"console"`` for the text battle,
-    ``"gui"`` for the graphical battle,
     ``"dungeon"`` for the dungeon crawler,
     ``"deckbuilder"`` to launch the deck builder,
     ``"bestiary"`` to view the bestiary,
@@ -14,14 +12,6 @@ def run_start_menu():
     or ``None`` if the user closes the menu without making a choice.
     """
     selection = {"mode": None}
-
-    def choose_console():
-        selection["mode"] = "console"
-        root.quit()
-
-    def choose_gui():
-        selection["mode"] = "gui"
-        root.quit()
 
     def choose_dungeon():
         selection["mode"] = "dungeon"
@@ -47,8 +37,6 @@ def run_start_menu():
 
     tk.Label(root, text="Medieval Duel", font=("Arial", 24)).pack(pady=10)
 
-    tk.Button(root, text="Console Battle", width=20, command=choose_console).pack(pady=5)
-    tk.Button(root, text="GUI Battle", width=20, command=choose_gui).pack(pady=5)
     tk.Button(root, text="Dungeon Battle", width=20, command=choose_dungeon).pack(pady=5)
     tk.Button(root, text="Deck Builder", width=20, command=choose_deckbuilder).pack(pady=5)
     tk.Button(root, text="Bestiary", width=20, command=choose_bestiary).pack(pady=5)


### PR DESCRIPTION
## Summary
- trim main menu options
- redesign Bestiary and Card Library viewers with clickable lists
- simplify main menu code
- enforce end-of-turn logic in GUI battles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc11d8cac8323a9cb9532a7f501fd