### PR TITLE
Improve battle GUI flow and card scaling

### DIFF
--- a/battle/gui.py
+++ b/battle/gui.py
@@ -85,6 +85,8 @@ class BattleGUI:
                             command=lambda i=idx: self.play_card(i))
             btn.pack(fill="x")
             self.card_buttons.append(btn)
+        tk.Button(self.action_frame, text="Back",
+                  command=self.clear_action_frame).pack(fill="x")
 
     def show_items(self):
         self.clear_action_frame()
@@ -97,6 +99,8 @@ class BattleGUI:
                             command=lambda i=idx: self.use_item(i))
             btn.pack(fill="x")
             self.item_buttons.append(btn)
+        tk.Button(self.action_frame, text="Back",
+                  command=self.clear_action_frame).pack(fill="x")
 
     def flee(self):
         self.log("You fled the battle!")
@@ -166,6 +170,7 @@ class BattleGUI:
         self.clear_action_frame()
         self.player.update_effects()
         self.player.regenerate()
+        self.player.refill_hand()
         if self.player.is_defeated():
             self.update_labels()
             self.log("You lost the battle!")
@@ -173,6 +178,7 @@ class BattleGUI:
             self.root.quit()
             return
         self.update_labels()
+        self.show_hand()
         
     def start(self):
         self.player.refill_hand()

--- a/deck_builder.py
+++ b/deck_builder.py
@@ -6,16 +6,33 @@ from cards import Card
 from character_cards import CHARACTER_CARDS, UNIVERSAL_CARDS, CHARACTER_PROGRESSIONS
 
 
+def _scale_amount(cost, resource):
+    """Return a simple damage/heal amount based on card cost and resource."""
+    if resource.lower() == "mana":
+        return max(1, cost * 3)
+    return max(1, cost * 2)
+
+
 def _make_card(info):
-    """Convert a card info dictionary to a Card with simple placeholder effects."""
-    if info.get("type") == "Damage":
-        effect = lambda u, t: simple_damage(u, t, 5)
-    elif info.get("type") == "Buff":
-        effect = lambda u, t: simple_heal(u, u, 3)
+    """Convert a card info dictionary to a Card with scaled placeholder effects."""
+    ctype = info.get("type")
+    if ctype is None:
+        purpose = info.get("purpose", "").lower()
+        if "offense" in purpose:
+            ctype = "Damage"
+        elif "recovery" in purpose or "buff" in purpose or "support" in purpose:
+            ctype = "Buff"
+        else:
+            ctype = "Utility"
+    amount = _scale_amount(info.get("cost", 1), info.get("resource", "stamina"))
+    if ctype == "Damage":
+        effect = lambda u, t, a=amount: simple_damage(u, t, a)
+    elif ctype == "Buff":
+        effect = lambda u, t, a=amount: simple_heal(u, u, a)
     else:
         effect = lambda u, t: None
     card = Card(info["name"], info["cost"], info["resource"].lower(), effect, info.get("effect", ""))
-    card.type = info.get("type", "")
+    card.type = ctype or ""
     return card
 
 


### PR DESCRIPTION
## Summary
- add Back button when viewing cards or items in battle
- show player's hand automatically at the start of each turn
- scale placeholder card effects from deck builder based on cost

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc33576b0832395ea072afba8de8d