### PR TITLE
Enhance battle UI with health bar and damage logs

### DIFF
--- a/battle/dungeon_gui.py
+++ b/battle/dungeon_gui.py
@@ -26,7 +26,24 @@ class DungeonBattleGUI(BattleGUI):
     def redraw(self):
         self.canvas.delete("all")
         self.canvas.create_image(100, 220, image=self.player_img)
-        self.canvas.create_image(300, 80, image=self.enemy_img)
+        enemy_x, enemy_y = 300, 80
+        self.canvas.create_image(enemy_x, enemy_y, image=self.enemy_img)
+
+        # Enemy health bar
+        bar_width = 100
+        bar_height = 10
+        x0 = enemy_x - bar_width // 2
+        y0 = enemy_y - 40
+        hp_frac = max(0, self.enemy.hp) / self.enemy.max_hp
+        # draw missing health in red background
+        self.canvas.create_rectangle(x0, y0, x0 + bar_width, y0 + bar_height,
+                                     fill="red", outline="white")
+        # overlay current health in green
+        self.canvas.create_rectangle(x0, y0, x0 + int(bar_width * hp_frac),
+                                     y0 + bar_height, fill="green", outline="")
+        # enemy name above bar
+        self.canvas.create_text(enemy_x, y0 - 10, text=self.enemy.name,
+                                fill="white")
 
     def update_labels(self):
         super().update_labels()

--- a/battle/engine.py
+++ b/battle/engine.py
@@ -5,7 +5,8 @@ from enemy_ai import take_turn
 
 
 def simple_damage(user, target, amount):
-    target.hp -= amount
+    """Deal ``amount`` damage from ``user`` to ``target``."""
+    target.take_damage(amount)
     print(f"{user.name} deals {amount} damage to {target.name}!")
 
 

--- a/battle/gui.py
+++ b/battle/gui.py
@@ -115,10 +115,19 @@ class BattleGUI:
 
     def play_card(self, index):
         card = self.player.hand[index]
+        enemy_hp_before = self.enemy.hp
+        player_hp_before = self.player.hp
         if not self.player.play_card(index, self.enemy):
             self.log("Failed to play card!")
             return
-        self.log(f"You play {card.name}")
+        damage = max(0, enemy_hp_before - self.enemy.hp)
+        heal = max(0, self.player.hp - player_hp_before)
+        msg = f"You play {card.name}"
+        if damage:
+            msg += f" dealing {damage} damage"
+        if heal:
+            msg += f" and heal {heal} HP"
+        self.log(msg)
         self.update_labels()
         if self.enemy.is_defeated():
             self.log("You won the battle!")
@@ -129,9 +138,22 @@ class BattleGUI:
         self.end_player_turn()
 
     def use_item(self, index):
+        hp_before = self.player.hp
+        mana_before = self.player.mana
+        stamina_before = self.player.stamina
         if not self.player.use_item(index):
             return
-        self.log(f"You use {self.player.name}'s item")
+        delta_hp = self.player.hp - hp_before
+        delta_mana = self.player.mana - mana_before
+        delta_stamina = self.player.stamina - stamina_before
+        msg = f"You use {self.player.name}'s item"
+        if delta_hp > 0:
+            msg += f" and recover {delta_hp} HP"
+        if delta_mana > 0:
+            msg += f" and restore {delta_mana} mana"
+        if delta_stamina > 0:
+            msg += f" and restore {delta_stamina} stamina"
+        self.log(msg)
         self.update_labels()
         self.end_player_turn()
 
@@ -155,8 +177,13 @@ class BattleGUI:
                 self.log(f"{self.enemy.name} hesitates and redraws.")
             else:
                 card = self.enemy.hand[idx]
+                player_hp_before = self.player.hp
                 self.enemy.play_card(idx, self.player)
-                self.log(f"Enemy plays {card.name}")
+                damage = max(0, player_hp_before - self.player.hp)
+                msg = f"{self.enemy.name} plays {card.name}"
+                if damage:
+                    msg += f" dealing {damage} damage"
+                self.log(msg)
         self.enemy.refill_hand()
         self.update_labels()
         if self.player.is_defeated():


### PR DESCRIPTION
## Summary
- add helper to apply damage using `take_damage`
- show damage/healing details in `BattleGUI` logs
- log item effects with amount restored
- display enemy name and health bar in dungeon GUI

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc94ecf3483239417d175b552cfd7