### PR TITLE
Add level scaling and bestiary enemies

### DIFF
--- a/battle/engine.py
+++ b/battle/engine.py
@@ -5,14 +5,16 @@ from enemy_ai import take_turn
 
 
 def simple_damage(user, target, amount):
-    """Deal ``amount`` damage from ``user`` to ``target``."""
-    target.take_damage(amount)
-    print(f"{user.name} deals {amount} damage to {target.name}!")
+    """Deal ``amount`` damage from ``user`` to ``target`` with level scaling."""
+    scaled = int(amount * (1 + 0.1 * (user.level - 1)))
+    target.take_damage(scaled)
+    print(f"{user.name} deals {scaled} damage to {target.name}!")
 
 
 def simple_heal(user, target, amount):
-    user.hp = min(user.max_hp, user.hp + amount)
-    print(f"{user.name} heals {amount} HP!")
+    scaled = int(amount * (1 + 0.1 * (user.level - 1)))
+    user.hp = min(user.max_hp, user.hp + scaled)
+    print(f"{user.name} heals {scaled} HP!")
 
 
 def create_basic_cards():

--- a/bestiary.py
+++ b/bestiary.py
@@ -1,3 +1,7 @@
+from characters import Character
+from cards import Card
+from battle.engine import simple_damage
+
 BESTIARY = [
     {
         "name": "Goblin",
@@ -330,3 +334,27 @@ BESTIARY = [
         "tactics": "Use ear protection or silence magic to counter her wail. Holy magic disrupts her form."
     }
 ]
+
+
+def create_enemy_for_level(level: int) -> Character:
+    """Return a simple enemy ``Character`` from ``BESTIARY`` scaled by level."""
+    idx = min(len(BESTIARY) - 1, max(0, level // 2))
+    data = BESTIARY[idx]
+
+    attack = Card(
+        "Attack",
+        cost=1,
+        resource_type="stamina",
+        effect_function=lambda u, t, dmg=data["damage"]: simple_damage(u, t, dmg),
+        description=f"Deal {data['damage']} damage."
+    )
+
+    enemy = Character(
+        name=data["name"],
+        hp=data["hp"],
+        mana=0,
+        stamina=5,
+        deck=[attack] * 5,
+        level=level,
+    )
+    return enemy

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from deck_builder import run_deck_builder_menu
 from start_menu import run_start_menu
 from characters import Character
 from items import create_basic_items
+from bestiary import create_enemy_for_level
 from bestiary_viewer import show_bestiary
 from card_library_viewer import show_card_library
 
@@ -27,10 +28,11 @@ def main():
         else:
             if player is None:
                 player = run_deck_builder_menu()
-            enemy = build_sample_character("Enemy")
             if mode == "dungeon":
+                enemy = create_enemy_for_level(player.level)
                 DungeonBattleGUI(player, enemy).start()
             else:
+                enemy = build_sample_character("Enemy")
                 run_battle(player, enemy)
 
         mode = run_start_menu()


### PR DESCRIPTION
## Summary
- scale basic card damage and healing by character level
- add helper to create an enemy from the bestiary for a given level
- spawn a level-based bestiary enemy in dungeon battles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bca8bef8c8323977b57abf84124c6