### PR TITLE
Implement universal card effects

### DIFF
--- a/effects/status_effects.py
+++ b/effects/status_effects.py
@@ -39,3 +39,39 @@ class DamageOverTime(StatusEffect):
 
     def on_turn(self, target):
         target.take_damage(self.amount)
+
+
+class StatBuff(StatusEffect):
+    """Temporarily modify a character stat or attribute."""
+
+    def __init__(self, name: str, duration: int, attr: str, amount: int):
+        super().__init__(name, duration)
+        self.attr = attr
+        self.amount = amount
+
+    def on_apply(self, target):
+        setattr(target, self.attr, getattr(target, self.attr, 0) + self.amount)
+
+    def on_expire(self, target):
+        setattr(target, self.attr, getattr(target, self.attr, 0) - self.amount)
+
+
+class DodgeBuff(StatusEffect):
+    """Increase dodge chance by a flat amount."""
+
+    def __init__(self, name: str, duration: int, chance: int):
+        super().__init__(name, duration)
+        self.chance = chance
+
+    def on_apply(self, target):
+        target.dodge_chance += self.chance
+
+    def on_expire(self, target):
+        target.dodge_chance = max(0, target.dodge_chance - self.chance)
+
+
+class CounterSpell(StatusEffect):
+    """Negate the next mana-based card used against the target."""
+
+    def __init__(self):
+        super().__init__("Counter Spell", 1)


### PR DESCRIPTION
## Summary
- add StatBuff, DodgeBuff and CounterSpell status effects
- give Character dodge chance and helper methods for effects
- counter spell negates mana cards in `play_card`
- integrate dodge into `simple_damage`
- implement a new set of universal cards with real effects
- map card names to effects when building decks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3c61959c8323bdf7c37a1186bc1e