### PR TITLE
Fix dungeon victory flow

### DIFF
--- a/battle/dungeon_gui.py
+++ b/battle/dungeon_gui.py
@@ -1,6 +1,9 @@
 import tkinter as tk
+from tkinter import messagebox
+import random
 from PIL import Image, ImageDraw, ImageTk
 from .gui import BattleGUI
+from items import create_basic_items
 
 
 class DungeonBattleGUI(BattleGUI):
@@ -15,6 +18,7 @@ class DungeonBattleGUI(BattleGUI):
     def __init__(self, player, enemy):
         super().__init__(player, enemy)
         self.root.title("Dungeon Battle")
+        self.continue_dungeon = False
 
         self.canvas = tk.Canvas(self.root, width=400, height=300, bg="black")
         self.canvas.pack(before=self.log_text, fill="both", expand=True)
@@ -48,3 +52,22 @@ class DungeonBattleGUI(BattleGUI):
     def update_labels(self):
         super().update_labels()
         self.redraw()
+
+    def end_battle(self, won: bool):
+        """Handle battle conclusion with loot and continue prompt."""
+        self.victory = won
+        if won:
+            self.player.gain_xp(50)
+            loot = None
+            if random.random() < 0.5:
+                loot = random.choice(create_basic_items())
+                self.player.items.append(loot)
+            msg = "You won the battle!"
+            if loot:
+                msg += f"\nYou found {loot.name}!"
+            msg += "\nContinue to next battle?"
+            self.continue_dungeon = messagebox.askyesno("Victory", msg)
+        else:
+            messagebox.showinfo("Defeat", "You lost the battle!")
+            self.continue_dungeon = False
+        self.root.quit()

--- a/battle/gui.py
+++ b/battle/gui.py
@@ -52,6 +52,12 @@ class BattleGUI:
 
         self.card_buttons = []
         self.item_buttons = []
+        self.victory = None
+
+    def end_battle(self, won: bool):
+        """Set battle result and close the window."""
+        self.victory = won
+        self.root.quit()
 
     # Utility methods -----------------------------------------------------
     def _stats(self, c):
@@ -106,7 +112,7 @@ class BattleGUI:
     def flee(self):
         self.log("You fled the battle!")
         messagebox.showinfo("Flee", "You fled the battle!")
-        self.root.quit()
+        self.end_battle(False)
 
     def fold(self):
         self.player.discard_hand()
@@ -130,10 +136,7 @@ class BattleGUI:
         self.log(msg)
         self.update_labels()
         if self.enemy.is_defeated():
-            self.log("You won the battle!")
-            messagebox.showinfo("Victory", "You won the battle!")
-            self.player.gain_xp(50)
-            self.root.quit()
+            self.end_battle(True)
             return
         self.end_player_turn()
 
@@ -163,10 +166,7 @@ class BattleGUI:
         self.enemy.regenerate()
         if self.enemy.is_defeated():
             self.update_labels()
-            self.log("You won the battle!")
-            messagebox.showinfo("Victory", "You won the battle!")
-            self.player.gain_xp(50)
-            self.root.quit()
+            self.end_battle(True)
             return
         if not self.enemy.hand:
             self.enemy.refill_hand()
@@ -188,8 +188,7 @@ class BattleGUI:
         self.update_labels()
         if self.player.is_defeated():
             self.log("You lost the battle!")
-            messagebox.showinfo("Defeat", "You lost the battle!")
-            self.root.quit()
+            self.end_battle(False)
         else:
             self.new_turn()
 
@@ -207,8 +206,7 @@ class BattleGUI:
         if self.player.is_defeated():
             self.update_labels()
             self.log("You lost the battle!")
-            messagebox.showinfo("Defeat", "You lost the battle!")
-            self.root.quit()
+            self.end_battle(False)
             return
         self.update_labels()
         self.show_hand()
@@ -218,4 +216,5 @@ class BattleGUI:
         self.enemy.refill_hand()
         self.new_turn()
         self.root.mainloop()
+        self.root.destroy()
 

--- a/main.py
+++ b/main.py
@@ -29,8 +29,12 @@ def main():
             if player is None:
                 player = run_deck_builder_menu()
             if mode == "dungeon":
-                enemy = create_enemy_for_level(player.level)
-                DungeonBattleGUI(player, enemy).start()
+                continue_dungeon = True
+                while continue_dungeon:
+                    enemy = create_enemy_for_level(player.level)
+                    gui = DungeonBattleGUI(player, enemy)
+                    gui.start()
+                    continue_dungeon = gui.continue_dungeon
             else:
                 enemy = build_sample_character("Enemy")
                 run_battle(player, enemy)


### PR DESCRIPTION
## Summary
- refine `BattleGUI` to track battle outcome
- add victory/defeat flow with loot and continue option in `DungeonBattleGUI`
- loop dungeon battles in main.py based on player choice

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c3fccde4c832399cdad08b1fe133e