### PR TITLE
Add summons and card metadata

### DIFF
--- a/battle/dungeon_gui.py
+++ b/battle/dungeon_gui.py
@@ -33,6 +33,18 @@ class DungeonBattleGUI(BattleGUI):
         enemy_x, enemy_y = 300, 80
         self.canvas.create_image(enemy_x, enemy_y, image=self.enemy_img)
 
+        # Player summons
+        px = 60
+        for sm in self.player.summons:
+            self.canvas.create_oval(px, 180, px + 20, 200, fill=sm.color)
+            px += 25
+
+        # Enemy summons
+        ex = 340
+        for sm in self.enemy.summons:
+            self.canvas.create_oval(ex, 40, ex + 20, 60, fill=sm.color)
+            ex += 25
+
         # Enemy health bar
         bar_width = 100
         bar_height = 10

--- a/battle/engine.py
+++ b/battle/engine.py
@@ -68,6 +68,8 @@ def run_battle(player: Character, enemy: Character):
         enemy.regenerate()
         player.update_effects()
         enemy.update_effects()
+        player.update_summons(enemy)
+        enemy.update_summons(player)
         turn += 1
         print(f"\n-- Turn {turn} --")
         print(f"{player.name} HP:{player.hp} Mana:{player.mana} Stamina:{player.stamina}")

--- a/battle/gui.py
+++ b/battle/gui.py
@@ -163,6 +163,7 @@ class BattleGUI:
     # Turn management -----------------------------------------------------
     def enemy_turn(self):
         self.enemy.update_effects()
+        self.enemy.update_summons(self.player)
         self.enemy.regenerate()
         if self.enemy.is_defeated():
             self.update_labels()
@@ -201,6 +202,7 @@ class BattleGUI:
     def new_turn(self):
         self.clear_action_frame()
         self.player.update_effects()
+        self.player.update_summons(self.enemy)
         self.player.regenerate()
         self.player.refill_hand()
         if self.player.is_defeated():

--- a/cards/__init__.py
+++ b/cards/__init__.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Callable
+from dataclasses import dataclass, field
+from typing import Callable, Dict
 
 
 @dataclass
@@ -11,3 +11,8 @@ class Card:
     resource_type: str
     effect_function: Callable
     description: str = ""
+    card_type: str = ""
+    rarity: str = "common"
+    level_requirement: int = 1
+    stat_requirements: Dict[str, int] = field(default_factory=dict)
+    category: str = "universal"

--- a/character_cards.py
+++ b/character_cards.py
@@ -284,16 +284,16 @@ CHARACTER_CARDS = {
 }
 
 UNIVERSAL_CARDS = [
-    {"name": "Strike", "cost": 1, "resource": "Stamina", "effect": "Perform a basic attack with your equipped weapon.", "purpose": "Offense – damage based on Strength"},
-    {"name": "Defend", "cost": 1, "resource": "Stamina", "effect": "Adopt a defensive stance, reducing damage taken until your next turn.", "purpose": "Defense – increases Resilience briefly"},
-    {"name": "Dodge", "cost": 1, "resource": "Stamina", "effect": "Make an evasive maneuver to avoid the next attack.", "purpose": "Defense – negates one incoming attack"},
-    {"name": "Healing Potion", "cost": 0, "resource": "Stamina", "effect": "Consume a potion to restore a moderate amount of health.", "purpose": "Recovery – heals HP"},
-    {"name": "Mana Potion", "cost": 0, "resource": "Stamina", "effect": "Drink a potion to regain a moderate amount of mana.", "purpose": "Recovery – restores mana"},
-    {"name": "Focus", "cost": 1, "resource": "Mana", "effect": "Concentrate to sharpen your next action.", "purpose": "Buff – improves offense of your next move"},
-    {"name": "Dispel Magic", "cost": 2, "resource": "Mana", "effect": "Release a burst of nullifying energy to remove a magical buff from an enemy or a debuff from an ally.", "purpose": "Utility – negates one magical effect"},
-    {"name": "Retreat", "cost": 1, "resource": "Stamina", "effect": "Swiftly move out of melee range without provoking attacks.", "purpose": "Mobility – reposition safely"},
-    {"name": "Inspire", "cost": 1, "resource": "Stamina", "effect": "Encourage an ally, boosting their damage and resistance for a short time.", "purpose": "Support – minor all-round boost"},
-    {"name": "Plan Ahead", "cost": 1, "resource": "Mana", "effect": "Take time to strategize, drawing 2 extra cards from your deck.", "purpose": "Utility – increases your options"}
+    {"name": "Strike", "cost": 1, "resource": "Stamina", "effect": "Perform a basic attack with your equipped weapon.", "purpose": "Offense – damage based on Strength", "category": "universal", "rarity": "common"},
+    {"name": "Defend", "cost": 1, "resource": "Stamina", "effect": "Adopt a defensive stance, reducing damage taken until your next turn.", "purpose": "Defense – increases Resilience briefly", "category": "universal", "rarity": "common"},
+    {"name": "Dodge", "cost": 1, "resource": "Stamina", "effect": "Make an evasive maneuver to avoid the next attack.", "purpose": "Defense – negates one incoming attack", "category": "universal", "rarity": "common"},
+    {"name": "Healing Potion", "cost": 0, "resource": "Stamina", "effect": "Consume a potion to restore a moderate amount of health.", "purpose": "Recovery – heals HP", "category": "universal", "rarity": "common"},
+    {"name": "Mana Potion", "cost": 0, "resource": "Stamina", "effect": "Drink a potion to regain a moderate amount of mana.", "purpose": "Recovery – restores mana", "category": "universal", "rarity": "common"},
+    {"name": "Focus", "cost": 1, "resource": "Mana", "effect": "Concentrate to sharpen your next action.", "purpose": "Buff – improves offense of your next move", "category": "universal", "rarity": "uncommon"},
+    {"name": "Dispel Magic", "cost": 2, "resource": "Mana", "effect": "Release a burst of nullifying energy to remove a magical buff from an enemy or a debuff from an ally.", "purpose": "Utility – negates one magical effect", "category": "universal", "rarity": "uncommon"},
+    {"name": "Retreat", "cost": 1, "resource": "Stamina", "effect": "Swiftly move out of melee range without provoking attacks.", "purpose": "Mobility – reposition safely", "category": "universal", "rarity": "common"},
+    {"name": "Inspire", "cost": 1, "resource": "Stamina", "effect": "Encourage an ally, boosting their damage and resistance for a short time.", "purpose": "Support – minor all-round boost", "category": "universal", "rarity": "uncommon"},
+    {"name": "Plan Ahead", "cost": 1, "resource": "Mana", "effect": "Take time to strategize, drawing 2 extra cards from your deck.", "purpose": "Utility – increases your options", "category": "universal", "rarity": "rare"}
 ]
 
 # Per-character stat progressions used by the leveling system

--- a/deck_builder.py
+++ b/deck_builder.py
@@ -47,11 +47,26 @@ def _make_card(info):
         if ctype == "Damage":
             effect = lambda u, t, a=amount: simple_damage(u, t, a)
         elif ctype == "Buff":
-            effect = lambda u, t, a=amount: simple_heal(u, u, a)
+            effect = lambda u, t, a=amount: u.add_effect(StatBuff(info.get("name", "Buff"), 2, "strength_mod", a))
+        elif ctype == "Debuff":
+            effect = lambda u, t, a=amount: t.add_effect(StatBuff(info.get("name", "Debuff"), 2, "strength_mod", -a))
+        elif ctype == "Summon":
+            from summons import Summon
+            effect = lambda u, t, a=amount: u.add_summon(Summon(info.get("name", "Summon"), a, info.get("duration", 3)))
         else:
             effect = lambda u, t: None
-    card = Card(info["name"], info.get("cost", 1), info.get("resource", "stamina").lower(), effect, info.get("effect", ""))
-    card.type = ctype or ""
+    card = Card(
+        info["name"],
+        info.get("cost", 1),
+        info.get("resource", "stamina").lower(),
+        effect,
+        info.get("effect", ""),
+        card_type=ctype or "",
+        rarity=info.get("rarity", "common"),
+        level_requirement=info.get("level", 1),
+        stat_requirements=info.get("stats", {}),
+        category=info.get("category", "universal"),
+    )
     return card
 
 
@@ -178,7 +193,7 @@ def run_deck_builder_menu():
         row = tk.Frame(avail_frame, bd=1, relief="solid", padx=2, pady=2)
         row.pack(fill="x", pady=2)
 
-        info = f"{c.name} ({c.type}) - Cost: {c.cost} {c.resource_type}\n{c.description}"
+        info = f"{c.name} ({c.card_type}) - Cost: {c.cost} {c.resource_type}\n{c.description}"
         tk.Label(row, text=info, justify="left", anchor="w", wraplength=400).grid(row=0, column=0, sticky="w")
 
         ctrl = tk.Frame(row)

--- a/summons.py
+++ b/summons.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+
+
+@dataclass
+class Summon:
+    """Simple summoned creature that acts each turn."""
+
+    name: str
+    damage: int
+    duration: int
+    color: str = "gray"
+
+    def act(self, owner, target):
+        """Apply this summon’s effect to the target."""
+        if self.damage > 0:
+            bonus = getattr(owner, "stat_mod", lambda s: 0)("thaumaturgy")
+            target.take_damage(max(0, self.damage + bonus))
+        self.duration -= 1
+
+    def expired(self) -> bool:
+        return self.duration <= 0

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -37,6 +37,26 @@ class TestCharacterSystems(unittest.TestCase):
         self.assertEqual(enemy.hp, 8)
         self.assertEqual(len(enemy.effects), 0)
 
+    def test_summon_damage(self):
+        from summons import Summon
+        player = Character("Summoner", 10, 10, 10)
+        enemy = Character("Target", 10, 10, 10)
+        player.add_summon(Summon("Imp", 2, 2))
+        player.update_summons(enemy)
+        self.assertEqual(enemy.hp, 8)
+        player.update_summons(enemy)
+        self.assertEqual(enemy.hp, 6)
+        self.assertEqual(len(player.summons), 0)
+
+    def test_card_requirements(self):
+        card = Card("High", 1, "mana", lambda u, t: None, level_requirement=2)
+        char = Character("Mage", 10, 10, 10, deck=[card])
+        char.hand = [card]
+        self.assertFalse(char.play_card(0, None))
+        char.level = 2
+        char.mana = 1
+        self.assertTrue(char.play_card(0, None))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expand `Card` with rarity, category, and requirements
- add `Summon` helper for temporary allies
- support summons in `Character` and battle engine
- draw summoned helpers in dungeon GUI
- add metadata to universal cards
- update deck building to read new fields
- test summon damage and card requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c483f42008323b86cb35f9c2539be