### PR TITLE
Add new cards and effects

### DIFF
--- a/battle/engine.py
+++ b/battle/engine.py
@@ -75,6 +75,10 @@ def run_battle(player: Character, enemy: Character):
         print(f"\n-- Turn {turn} --")
         print(f"{player.name} HP:{player.hp} Mana:{player.mana} Stamina:{player.stamina}")
         print(f"{enemy.name} HP:{enemy.hp} Mana:{enemy.mana} Stamina:{enemy.stamina}")
+        if getattr(player, "stunned", False):
+            print(f"{player.name} is stunned and cannot act!")
+            take_turn(enemy, player)
+            continue
         print("Your hand:")
         for idx, card in enumerate(player.hand):
             print(f"{idx+1}. {card.name} - Cost {card.cost} {card.resource_type} :: {card.description}")

--- a/character_cards.py
+++ b/character_cards.py
@@ -340,7 +340,31 @@ UNIVERSAL_CARDS = [
     {"name": "Rally", "cost": 2, "resource": "Stamina", "type": "Buff", "effect": "+2 Strength for 2 turns.", "rarity": "uncommon", "level": 1},
     {"name": "Anticipate", "cost": 1, "resource": "Stamina", "type": "Utility", "effect": "View enemy’s next card and cancel if cost 1 or less.", "rarity": "rare", "level": 1},
     {"name": "Soul Exchange", "cost": 3, "resource": "Mana", "type": "Utility", "effect": "Swap HP with opponent if yours is lower.", "rarity": "rare", "level": 1},
-    {"name": "Overdraw", "cost": 0, "resource": "Stamina", "type": "Utility", "effect": "Draw 2 cards, lose 2 HP.", "rarity": "common", "level": 1}
+    {"name": "Overdraw", "cost": 0, "resource": "Stamina", "type": "Utility", "effect": "Draw 2 cards, lose 2 HP.", "rarity": "common", "level": 1},
+
+    # -- Newly added common cards --
+    {"name": "Spirit Lash", "cost": 1, "resource": "Mana", "type": "Damage", "effect": "Deal 2 + Thaumaturgy damage. +1 if target has a debuff.", "rarity": "common", "level": 1},
+    {"name": "Cunning Step", "cost": 1, "resource": "Stamina", "type": "Utility", "effect": "Gain +2 Agility until next turn and draw a card.", "rarity": "common", "level": 1},
+    {"name": "Magic Sparkle", "cost": 1, "resource": "Mana", "type": "Utility", "effect": "Reveal the top card of the enemy deck.", "rarity": "common", "level": 1},
+    {"name": "Guarded Heart", "cost": 1, "resource": "Stamina", "type": "Buff", "effect": "+1 Resilience for 2 turns.", "rarity": "common", "level": 1},
+    {"name": "Force Push", "cost": 1, "resource": "Mana", "type": "Damage", "effect": "Deal 2 + Strength damage and push the enemy back.", "rarity": "common", "level": 1},
+    {"name": "Fade Step", "cost": 1, "resource": "Stamina", "type": "Utility", "effect": "Gain 20% dodge chance next turn.", "rarity": "common", "level": 1},
+    {"name": "Stone Grip", "cost": 1, "resource": "Stamina", "type": "Debuff", "effect": "Reduce enemy Agility by 1 this turn.", "rarity": "common", "level": 1},
+    {"name": "Ember Shot", "cost": 1, "resource": "Mana", "type": "Damage", "effect": "Deal 2 + Thaumaturgy fire damage. 15% chance to Burn (1 dmg for 2 turns).", "rarity": "common", "level": 1},
+    {"name": "Tactic Study", "cost": 1, "resource": "Mana", "type": "Utility", "effect": "Look at the top two cards of your deck and swap them.", "rarity": "common", "level": 1},
+    {"name": "Intimidate", "cost": 1, "resource": "Stamina", "type": "Debuff", "effect": "Lower enemy Strength by 1 for 2 turns.", "rarity": "common", "level": 1},
+
+    # -- Newly added uncommon cards --
+    {"name": "Whirlwind Slash", "cost": 2, "resource": "Stamina", "type": "Damage", "effect": "Deal 3 + Strength damage. 25% chance to Weaken the enemy.", "rarity": "uncommon", "level": 5, "stats": {"strength": 3}},
+    {"name": "Ice Shards", "cost": 2, "resource": "Mana", "type": "Damage", "effect": "Deal 2 + Thaumaturgy damage and Freeze the enemy (skip next action).", "rarity": "uncommon", "level": 5, "stats": {"thaumaturgy": 3}},
+    {"name": "Barrier Bubble", "cost": 2, "resource": "Mana", "type": "Buff", "effect": "Negate the next source of damage.", "rarity": "uncommon", "level": 5, "stats": {"resilience": 3}},
+    {"name": "Acrobat's Spin", "cost": 2, "resource": "Stamina", "type": "Utility", "effect": "Remove movement debuffs. Gain +2 Agility next turn.", "rarity": "uncommon", "level": 5, "stats": {"agility": 3}},
+    {"name": "Shock Infusion", "cost": 2, "resource": "Mana", "type": "Damage", "effect": "Deal 3 + Thaumaturgy damage (double if target stunned).", "rarity": "uncommon", "level": 5, "stats": {"thaumaturgy": 3}},
+
+    # -- Newly added rare cards --
+    {"name": "Cataclysm Blast", "cost": 4, "resource": "Mana", "type": "Damage", "effect": "Deal 7 + Thaumaturgy damage (9 if target has 2+ effects).", "rarity": "rare", "level": 10, "stats": {"thaumaturgy": 4}},
+    {"name": "Phoenix Pact", "cost": 3, "resource": "Mana", "type": "Utility", "effect": "If you are KO'd this turn, revive at 5 HP next turn.", "rarity": "rare", "level": 10, "stats": {"resilience": 4}},
+    {"name": "Storm Avatar", "cost": 4, "resource": "Mana", "type": "Buff", "effect": "+2 to Strength, Agility and Resilience for 2 turns.", "rarity": "rare", "level": 10, "stats": {"strength": 4}}
 ]
 
 # Per-character stat progressions used by the leveling system

--- a/characters/__init__.py
+++ b/characters/__init__.py
@@ -39,6 +39,7 @@ class Character:
     effects: List[StatusEffect] = field(init=False, default_factory=list)
     dodge_chance: int = field(init=False, default=0)
     summons: List[Summon] = field(init=False, default_factory=list)
+    stunned: bool = field(init=False, default=False)
 
     def __post_init__(self):
         self.max_hp = self.hp
@@ -112,7 +113,12 @@ class Character:
         return True
 
     def take_damage(self, amount: int):
-        """Reduce HP by ``amount`` without dropping below zero."""
+        """Reduce HP by ``amount`` considering any active damage negation."""
+        from effects.status_effects import DamageNegate
+        for eff in list(self.effects):
+            if isinstance(eff, DamageNegate):
+                self.remove_effect(eff.name)
+                return
         self.hp = max(0, self.hp - amount)
 
     def heal(self, amount: int):

--- a/effects/status_effects.py
+++ b/effects/status_effects.py
@@ -75,3 +75,33 @@ class CounterSpell(StatusEffect):
     """Negate the next mana-based card used against the target."""
     name: str = "Counter Spell"
     duration: int = 1
+@dataclass
+class Stun(StatusEffect):
+    """Prevents the target from acting for the duration."""
+
+    def on_apply(self, target):
+        target.stunned = True
+
+    def on_expire(self, target):
+        target.stunned = False
+
+@dataclass
+class DamageNegate(StatusEffect):
+    """Negate the next instance of damage dealt to the target."""
+
+    def on_apply(self, target):
+        pass
+
+    def on_expire(self, target):
+        pass
+
+@dataclass
+class PhoenixPact(StatusEffect):
+    """Revive the target at a set HP if they fall this turn."""
+    revive_hp: int = 5
+
+    def on_expire(self, target):
+        if target.hp <= 0:
+            target.hp = self.revive_hp
+            target.stunned = False
+

--- a/enemy_ai.py
+++ b/enemy_ai.py
@@ -30,6 +30,9 @@ def choose_card_index(enemy: Character) -> Optional[int]:
 
 def take_turn(enemy: Character, player: Character) -> None:
     """Execute the enemy's turn against ``player``."""
+    if getattr(enemy, "stunned", False):
+        print(f"{enemy.name} is stunned and cannot act!")
+        return
     idx = choose_card_index(enemy)
     if idx is not None:
         card = enemy.hand[idx]


### PR DESCRIPTION
## Summary
- add stun, damage negate, and Phoenix Pact status effects
- allow characters to be stunned and block damage
- skip actions for stunned units in battle and AI
- implement helper to swap deck order
- expand effect map with new card logic
- enrich universal card library with new common, uncommon and rare cards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cfe70503083239fac182c066b80cd