### PR TITLE
Add player sheet and XP rewards

### DIFF
--- a/battle/dungeon_gui.py
+++ b/battle/dungeon_gui.py
@@ -69,7 +69,8 @@ class DungeonBattleGUI(BattleGUI):
         """Handle battle conclusion with loot and continue prompt."""
         self.victory = won
         if won:
-            self.player.gain_xp(50)
+            reward = getattr(self.enemy, "xp_reward", 50)
+            self.player.gain_xp(reward)
             loot = None
             if random.random() < 0.5:
                 loot = random.choice(create_basic_items())

--- a/bestiary.py
+++ b/bestiary.py
@@ -335,6 +335,11 @@ BESTIARY = [
     }
 ]
 
+# automatically assign an experience reward if missing
+for _idx, _beast in enumerate(BESTIARY, start=1):
+    if 'xp' not in _beast:
+        _beast['xp'] = _beast['hp'] + _beast['damage'] * 2
+
 
 def create_enemy_for_level(level: int) -> Character:
     """Return a simple enemy ``Character`` from ``BESTIARY`` scaled by level."""
@@ -361,4 +366,5 @@ def create_enemy_for_level(level: int) -> Character:
         agility_mod=data.get("agi", 0),
         resilience_mod=data.get("res", 0),
     )
+    enemy.xp_reward = data.get("xp", 50)
     return enemy

--- a/characters/__init__.py
+++ b/characters/__init__.py
@@ -20,6 +20,9 @@ class Character:
     level: int = 1
     xp: int = 0
     xp_to_next: int = 100
+    icon: str = "@"
+    unspent_points: int = 0
+    xp_reward: int = 0
     hp_regen: float = 1
     mana_regen: float = 1
     stamina_regen: float = 1
@@ -202,7 +205,26 @@ class Character:
         self.hp_regen += self.progression.get('hp_regen_per_level', 0.1)
         self.mana_regen += self.progression.get('mana_regen_per_level', 0.1)
         self.stamina_regen += self.progression.get('stamina_regen_per_level', 0.1)
+        self.unspent_points += 1
         # Restore stats on level up
         self.hp = self.max_hp
         self.mana = self.max_mana
         self.stamina = self.max_stamina
+
+    def allocate_point(self, stat: str) -> bool:
+        """Spend one stat point on ``stat`` if available."""
+        if self.unspent_points <= 0:
+            return False
+        stat = stat.lower()
+        if stat.startswith('str'):
+            self.strength_mod += 1
+        elif stat.startswith('tha'):
+            self.thaumaturgy_mod += 1
+        elif stat.startswith('agi'):
+            self.agility_mod += 1
+        elif stat.startswith('res'):
+            self.resilience_mod += 1
+        else:
+            return False
+        self.unspent_points -= 1
+        return True

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from battle.engine import create_basic_cards, run_battle
 from battle.dungeon_gui import DungeonBattleGUI
-from deck_builder import run_deck_builder_menu
+from player_sheet import run_player_sheet
 from start_menu import run_start_menu
 from characters import Character
 from items import create_basic_items
@@ -19,16 +19,17 @@ def main():
     player = None
     mode = run_start_menu()
     while mode:
-        if mode == "deckbuilder":
-            player = run_deck_builder_menu()
+        if mode == "playersheet":
+            player = run_player_sheet(player)
         elif mode == "bestiary":
             show_bestiary()
         elif mode == "library":
             show_card_library()
         else:
             if player is None:
-                player = run_deck_builder_menu()
+                player = run_player_sheet()
             if mode == "dungeon":
+                player = run_player_sheet(player)
                 continue_dungeon = True
                 while continue_dungeon:
                     enemy = create_enemy_for_level(player.level)

--- a/player_sheet.py
+++ b/player_sheet.py
@@ -1,0 +1,101 @@
+import tkinter as tk
+from characters import Character
+from deck_builder import run_deck_builder_menu
+from items import create_basic_items
+
+_ICON_OPTIONS = ["@", "#", "&", "%"]
+
+_DEFAULT_PROGRESSION = {
+    "base_hp": 20, "hp_per_level": 3,
+    "base_mana": 10, "mana_per_level": 2,
+    "base_stamina": 10, "stamina_per_level": 2,
+    "hp_regen": 1.0, "hp_regen_per_level": 0.1,
+    "mana_regen": 1.0, "mana_regen_per_level": 0.1,
+    "stamina_regen": 1.0, "stamina_regen_per_level": 0.1,
+}
+
+
+def _new_character():
+    prog = _DEFAULT_PROGRESSION
+    return Character(
+        name="Adventurer",
+        hp=prog["base_hp"],
+        mana=prog["base_mana"],
+        stamina=prog["base_stamina"],
+        items=create_basic_items()[:2],
+        progression=prog,
+        icon=_ICON_OPTIONS[0],
+    )
+
+
+def run_player_sheet(player: Character | None = None) -> Character:
+    """Display a player sheet for viewing and editing ``player``."""
+    if player is None:
+        player = _new_character()
+
+    root = tk.Tk()
+    root.title("Player Sheet")
+
+    name_var = tk.StringVar(value=player.name)
+    tk.Label(root, text="Name:").pack()
+    tk.Entry(root, textvariable=name_var).pack()
+
+    icon_var = tk.StringVar(value=player.icon)
+    icon_frame = tk.Frame(root)
+    icon_frame.pack(pady=5)
+    icon_label = tk.Label(icon_frame, textvariable=icon_var, font=("Arial", 32))
+    icon_label.pack(side="left")
+
+    def _next_icon(step: int):
+        idx = (_ICON_OPTIONS.index(icon_var.get()) + step) % len(_ICON_OPTIONS)
+        icon_var.set(_ICON_OPTIONS[idx])
+
+    tk.Button(icon_frame, text="<", command=lambda: _next_icon(-1)).pack(side="left")
+    tk.Button(icon_frame, text=">", command=lambda: _next_icon(1)).pack(side="left")
+
+    stats_frame = tk.Frame(root)
+    stats_frame.pack(pady=5)
+
+    def _refresh_stats():
+        for w in stats_frame.winfo_children():
+            w.destroy()
+        tk.Label(stats_frame, text=f"Level: {player.level}  XP: {player.xp}/{player.xp_to_next}").pack()
+        tk.Label(stats_frame, text=f"HP: {player.hp}/{player.max_hp}").pack()
+        tk.Label(stats_frame, text=f"Mana: {player.mana}/{player.max_mana}").pack()
+        tk.Label(stats_frame, text=f"Stamina: {player.stamina}/{player.max_stamina}").pack()
+        tk.Label(stats_frame, text=(
+            f"STR:{player.strength_mod} THA:{player.thaumaturgy_mod} "
+            f"AGI:{player.agility_mod} RES:{player.resilience_mod}"
+        )).pack()
+        if player.unspent_points:
+            tk.Label(stats_frame, text=f"Unspent points: {player.unspent_points}").pack()
+
+    _refresh_stats()
+
+    def allocate(stat: str):
+        if player.allocate_point(stat):
+            _refresh_stats()
+
+    alloc_frame = tk.Frame(root)
+    alloc_frame.pack(pady=2)
+    for stat in ["Strength", "Thaumaturgy", "Agility", "Resilience"]:
+        tk.Button(alloc_frame, text=stat, command=lambda s=stat: allocate(s)).pack(side="left")
+
+    def edit_deck():
+        run_deck_builder_menu(player)
+        _refresh_stats()
+
+    tk.Button(root, text="Edit Deck", command=edit_deck).pack(pady=5)
+
+    def _confirm():
+        player.name = name_var.get()
+        player.icon = icon_var.get()
+        root.quit()
+
+    tk.Button(root, text="Confirm", command=_confirm).pack(pady=5)
+    root.mainloop()
+    root.destroy()
+    return player
+
+if __name__ == "__main__":
+    run_player_sheet()

--- a/start_menu.py
+++ b/start_menu.py
@@ -6,7 +6,7 @@ def run_start_menu():
 
     Returns one of:
     ``"dungeon"`` for the dungeon crawler,
-    ``"deckbuilder"`` to launch the deck builder,
+    ``"playersheet"`` to open the player sheet,
     ``"bestiary"`` to view the bestiary,
     ``"library"`` to view the card library,
     or ``None`` if the user closes the menu without making a choice.
@@ -18,7 +18,7 @@ def run_start_menu():
         root.quit()
 
     def choose_deckbuilder():
-        selection["mode"] = "deckbuilder"
+        selection["mode"] = "playersheet"
         root.quit()
 
     def choose_bestiary():
@@ -38,7 +38,7 @@ def run_start_menu():
     tk.Label(root, text="Medieval Duel", font=("Arial", 24)).pack(pady=10)
 
     tk.Button(root, text="Dungeon Battle", width=20, command=choose_dungeon).pack(pady=5)
-    tk.Button(root, text="Deck Builder", width=20, command=choose_deckbuilder).pack(pady=5)
+    tk.Button(root, text="Player Sheet", width=20, command=choose_deckbuilder).pack(pady=5)
     tk.Button(root, text="Bestiary", width=20, command=choose_bestiary).pack(pady=5)
     tk.Button(root, text="Card Library", width=20, command=choose_library).pack(pady=5)
     tk.Button(root, text="Quit", width=20, command=exit_game).pack(pady=5)


### PR DESCRIPTION
## Summary
- implement Player Sheet UI for editing player and deck
- rename start menu entry to Player Sheet
- let player confirm character sheet before dungeon
- award XP per enemy using new xp_reward from bestiary
- adjust deck builder for current player only
- extend Character with icons, stat points, and XP reward

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0198b84c8323a8e699a8e50da9d3