### PR TITLE
Improve full-screen GUI and battle buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ The repository now includes two data modules used by the engine:
 - `character_cards.py` – card libraries and lore for each playable character along with the universal card set.
 
 These datasets are derived from the design codex and can be imported by other parts of the game for future content.
+
+## Card Types and Leveling
+
+Cards come in several rarity categories. **Common**, **Uncommon** and **Rare** cards can be found as loot or purchased from shops. **Unique** cards are tied to a particular character and are earned when that character levels up. The **Universal** card set is always available and can be used in any deck.
+
+Characters gain experience after battles and level up when they reach their XP threshold. Leveling up increases their maximum stats based on the progression table and grants an unspent stat point. Future updates will use level ups to award unique cards.

--- a/battle/gui.py
+++ b/battle/gui.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import messagebox
 from enemy_ai import choose_card_index
+from ui.fullscreen import create_fullscreen_root
 
 
 class BattleGUI:
@@ -9,8 +10,7 @@ class BattleGUI:
     def __init__(self, player, enemy):
         self.player = player
         self.enemy = enemy
-        self.root = tk.Tk()
-        self.root.title("Medieval Duel")
+        self.root = create_fullscreen_root("Medieval Duel")
 
         # Log output
         self.log_text = tk.Text(self.root, height=10, state="disabled")
@@ -32,14 +32,15 @@ class BattleGUI:
         self.option_frame = tk.Frame(self.root)
         self.option_frame.pack(fill="both", expand=True)
 
+        btn_opts = {"font": ("Arial", 16), "height": 2}
         self.battle_btn = tk.Button(self.option_frame, text="Battle",
-                                    command=self.show_hand)
+                                    command=self.show_hand, **btn_opts)
         self.flee_btn = tk.Button(self.option_frame, text="Flee",
-                                  command=self.flee)
+                                  command=self.flee, **btn_opts)
         self.items_btn = tk.Button(self.option_frame, text="Items",
-                                   command=self.show_items)
+                                   command=self.show_items, **btn_opts)
         self.fold_btn = tk.Button(self.option_frame, text="Fold",
-                                  command=self.fold)
+                                  command=self.fold, **btn_opts)
 
         self.battle_btn.grid(row=0, column=0, sticky="nsew", padx=5, pady=5)
         self.flee_btn.grid(row=0, column=1, sticky="nsew", padx=5, pady=5)
@@ -87,13 +88,35 @@ class BattleGUI:
     def show_hand(self):
         self.clear_action_frame()
         for idx, card in enumerate(self.player.hand):
-            text = f"{card.name} ({card.cost} {card.resource_type})"
-            btn = tk.Button(self.action_frame, text=text,
-                            command=lambda i=idx: self.play_card(i))
-            btn.pack(fill="x")
+            row, col = divmod(idx, 2)
+            est = ""
+            if getattr(card, "card_type", "").lower() == "damage":
+                dmg = card.cost * (3 if card.resource_type == "mana" else 2)
+                est = f"\nEst dmg: {dmg}"
+            text = (
+                f"{card.name}\nCost: {card.cost} {card.resource_type}\n"
+                f"{card.description}{est}"
+            )
+            btn = tk.Button(
+                self.action_frame,
+                text=text,
+                wraplength=200,
+                justify="left",
+                font=("Arial", 14),
+                command=lambda i=idx: self.play_card(i),
+            )
+            btn.grid(row=row, column=col, sticky="nsew", padx=5, pady=5)
             self.card_buttons.append(btn)
-        tk.Button(self.action_frame, text="Back",
-                  command=self.clear_action_frame).pack(fill="x")
+        for i in range(2):
+            self.action_frame.rowconfigure(i, weight=1)
+            self.action_frame.columnconfigure(i, weight=1)
+        tk.Button(
+            self.action_frame,
+            text="Back",
+            command=self.clear_action_frame,
+            font=("Arial", 14),
+            height=2,
+        ).grid(row=2, column=0, columnspan=2, pady=5)
 
     def show_items(self):
         self.clear_action_frame()
@@ -102,12 +125,22 @@ class BattleGUI:
             return
         for idx, item in enumerate(self.player.items):
             text = item.name
-            btn = tk.Button(self.action_frame, text=text,
-                            command=lambda i=idx: self.use_item(i))
-            btn.pack(fill="x")
+            btn = tk.Button(
+                self.action_frame,
+                text=text,
+                font=("Arial", 14),
+                height=2,
+                command=lambda i=idx: self.use_item(i),
+            )
+            btn.pack(fill="x", pady=5)
             self.item_buttons.append(btn)
-        tk.Button(self.action_frame, text="Back",
-                  command=self.clear_action_frame).pack(fill="x")
+        tk.Button(
+            self.action_frame,
+            text="Back",
+            command=self.clear_action_frame,
+            font=("Arial", 14),
+            height=2,
+        ).pack(fill="x", pady=5)
 
     def flee(self):
         self.log("You fled the battle!")

--- a/bestiary_viewer.py
+++ b/bestiary_viewer.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from bestiary import BESTIARY
+from ui.fullscreen import create_fullscreen_root
 
 
 def _show_monster(monster, parent):
@@ -25,8 +26,7 @@ def _show_monster(monster, parent):
 
 def show_bestiary():
     """Display bestiary entries as a clickable list of names."""
-    root = tk.Tk()
-    root.title("Bestiary")
+    root = create_fullscreen_root("Bestiary")
 
     frame = tk.Frame(root)
     frame.pack(fill="both", expand=True)

--- a/card_library_viewer.py
+++ b/card_library_viewer.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from character_cards import CHARACTER_CARDS, UNIVERSAL_CARDS
+from ui.fullscreen import create_fullscreen_root
 
 
 def _show_card(card, parent):
@@ -22,8 +23,7 @@ def _show_card(card, parent):
 
 def show_card_library():
     """Display all card names in a scrollable list."""
-    root = tk.Tk()
-    root.title("Card Library")
+    root = create_fullscreen_root("Card Library")
 
     frame = tk.Frame(root)
     frame.pack(fill="both", expand=True)

--- a/deck_builder.py
+++ b/deck_builder.py
@@ -1,5 +1,6 @@
 import tkinter as tk
 from battle.engine import simple_damage, simple_heal, gain_resource
+from ui.fullscreen import create_fullscreen_root
 from effects.status_effects import (
     StatBuff,
     DodgeBuff,
@@ -123,8 +124,7 @@ def run_deck_builder_menu(player: Character):
     card_infos = UNIVERSAL_CARDS
     card_prototypes = [_make_card(c) for c in card_infos]
 
-    root = tk.Tk()
-    root.title(f"Deck Builder - {player.name}")
+    root = create_fullscreen_root(f"Deck Builder - {player.name}")
 
     deck = []
     card_counts = {c.name: 0 for c in card_prototypes}

--- a/player_sheet.py
+++ b/player_sheet.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from characters import Character
 from deck_builder import run_deck_builder_menu
 from items import create_basic_items
+from ui.fullscreen import create_fullscreen_root
 
 _ICON_OPTIONS = ["@", "#", "&", "%"]
 
@@ -33,8 +34,7 @@ def run_player_sheet(player: Character | None = None) -> Character:
     if player is None:
         player = _new_character()
 
-    root = tk.Tk()
-    root.title("Player Sheet")
+    root = create_fullscreen_root("Player Sheet")
 
     name_var = tk.StringVar(value=player.name)
     tk.Label(root, text="Name:").pack()
@@ -85,14 +85,14 @@ def run_player_sheet(player: Character | None = None) -> Character:
         run_deck_builder_menu(player)
         _refresh_stats()
 
-    tk.Button(root, text="Edit Deck", command=edit_deck).pack(pady=5)
+    tk.Button(root, text="Edit Deck", command=edit_deck, font=("Arial", 16), height=2).pack(pady=10)
 
     def _confirm():
         player.name = name_var.get()
         player.icon = icon_var.get()
         root.quit()
 
-    tk.Button(root, text="Confirm", command=_confirm).pack(pady=5)
+    tk.Button(root, text="Confirm", command=_confirm, font=("Arial", 16), height=2).pack(pady=10)
     root.mainloop()
     root.destroy()
     return player

--- a/start_menu.py
+++ b/start_menu.py
@@ -1,4 +1,5 @@
 import tkinter as tk
+from ui.fullscreen import create_fullscreen_root
 
 
 def run_start_menu():
@@ -32,16 +33,16 @@ def run_start_menu():
     def exit_game():
         root.quit()
 
-    root = tk.Tk()
-    root.title("Medieval Duel - Main Menu")
+    root = create_fullscreen_root("Medieval Duel - Main Menu")
 
-    tk.Label(root, text="Medieval Duel", font=("Arial", 24)).pack(pady=10)
+    tk.Label(root, text="Medieval Duel", font=("Arial", 36)).pack(pady=20)
 
-    tk.Button(root, text="Dungeon Battle", width=20, command=choose_dungeon).pack(pady=5)
-    tk.Button(root, text="Player Sheet", width=20, command=choose_deckbuilder).pack(pady=5)
-    tk.Button(root, text="Bestiary", width=20, command=choose_bestiary).pack(pady=5)
-    tk.Button(root, text="Card Library", width=20, command=choose_library).pack(pady=5)
-    tk.Button(root, text="Quit", width=20, command=exit_game).pack(pady=5)
+    btn_opts = {"font": ("Arial", 20), "width": 20, "height": 2}
+    tk.Button(root, text="Dungeon Battle", command=choose_dungeon, **btn_opts).pack(pady=10)
+    tk.Button(root, text="Player Sheet", command=choose_deckbuilder, **btn_opts).pack(pady=10)
+    tk.Button(root, text="Bestiary", command=choose_bestiary, **btn_opts).pack(pady=10)
+    tk.Button(root, text="Card Library", command=choose_library, **btn_opts).pack(pady=10)
+    tk.Button(root, text="Quit", command=exit_game, **btn_opts).pack(pady=10)
 
     root.mainloop()
     root.destroy()

--- a/ui/fullscreen.py
+++ b/ui/fullscreen.py
@@ -1,0 +1,11 @@
+import tkinter as tk
+
+def create_fullscreen_root(title: str) -> tk.Tk:
+    """Return a Tk root window configured for fullscreen."""
+    root = tk.Tk()
+    root.title(title)
+    try:
+        root.attributes("-fullscreen", True)
+    except tk.TclError:
+        root.state("zoomed")
+    return root


### PR DESCRIPTION
## Summary
- add helper for fullscreen Tk windows
- enlarge start menu buttons and make fullscreen
- show player sheet, deck builder and other viewers fullscreen
- rework battle GUI buttons and card display
- document card rarity & leveling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d03fb11748323a836051ece84b3d2