### PR TITLE
Deck limit tweak and card type filters

### DIFF
--- a/summons.py
+++ b/summons.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Callable
 
 
 
@@ -11,10 +11,13 @@ class Summon:
     name: str
     damage: int
     duration: int
+    effect_fn: Optional[Callable[[object, object], None]] = None
     color: str = "gray"
 
     def act(self, owner, target):
         """Apply this summon’s effect to the target."""
+        if self.effect_fn:
+            self.effect_fn(owner, target)
         if self.damage > 0:
             bonus = getattr(owner, "stat_mod", lambda s: 0)("thaumaturgy")
             target.take_damage(max(0, self.damage + bonus))

--- a/tests/test_leveling.py
+++ b/tests/test_leveling.py
@@ -7,10 +7,9 @@ from cards import Card
 
 class TestLevelSystems(unittest.TestCase):
     def test_deck_size_progression(self):
-        self.assertEqual(get_deck_size_for_level(1), 3)
-        self.assertEqual(get_deck_size_for_level(5), 8)
-        self.assertEqual(get_deck_size_for_level(10), 15)
-        self.assertEqual(get_deck_size_for_level(20), 35)
+        # Deck size is now fixed at 20 regardless of level
+        for level in (1, 5, 10, 20):
+            self.assertEqual(get_deck_size_for_level(level), 20)
 
     def test_unique_unlock_progression(self):
         self.assertEqual(get_unique_unlocks_for_level(1), 3)


### PR DESCRIPTION
## Summary
- fix player deck size at 20 using `get_deck_size_for_level`
- add card type filter checkboxes in deck builder
- extend `Summon` to support custom per-turn effects
- update tests for constant deck size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d08a0a6048323a5e5b953f3662cf2