### PR TITLE
Add save system and improve start menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 from battle.engine import create_basic_cards, run_battle
 from battle.dungeon_gui import DungeonBattleGUI
 from player_sheet import run_player_sheet
-from start_menu import run_start_menu
+from start_menu import run_start_menu, run_title_menu
+from save_system import load_game
 from characters import Character
 from items import create_basic_items
 from bestiary import create_enemy_for_level
@@ -17,7 +18,19 @@ def build_sample_character(name):
 
 def main():
     player = None
-    mode = run_start_menu()
+    choice = run_title_menu()
+    if not choice:
+        return
+    if choice["mode"] == "load" or choice["mode"] == "continue":
+        player = load_game()
+    if player is None:
+        player = run_player_sheet()
+
+    result = run_start_menu(player)
+    mode = result.get("mode")
+    if result.get("player") is not None:
+        player = result.get("player")
+
     while mode:
         if mode == "playersheet":
             player = run_player_sheet(player)
@@ -40,7 +53,10 @@ def main():
                 enemy = build_sample_character("Enemy")
                 run_battle(player, enemy)
 
-        mode = run_start_menu()
+        result = run_start_menu(player)
+        if result.get("player") is not None:
+            player = result["player"]
+        mode = result.get("mode")
 
 
 if __name__ == "__main__":

--- a/save_system.py
+++ b/save_system.py
@@ -1,0 +1,71 @@
+import json
+import os
+from typing import Dict
+
+from characters import Character
+from deck_builder import _make_card
+from character_cards import CHARACTER_CARDS, UNIVERSAL_CARDS, CHARACTER_PROGRESSIONS
+
+_SAVE_PATH = "savegame.json"
+
+# Build a mapping of card name -> card prototype
+_CARD_LOOKUP: Dict[str, Character] = {}
+for info in UNIVERSAL_CARDS:
+    card = _make_card(info)
+    _CARD_LOOKUP[card.name] = card
+for char in CHARACTER_CARDS.values():
+    for info in char["cards"]:
+        card = _make_card(info)
+        _CARD_LOOKUP[card.name] = card
+
+_DEFAULT_CHARACTER = next(iter(CHARACTER_CARDS))
+_DEFAULT_PROGRESSION = CHARACTER_PROGRESSIONS[_DEFAULT_CHARACTER]
+
+
+def save_game(player: Character, path: str = _SAVE_PATH) -> None:
+    """Save ``player`` to ``path``."""
+    data = {
+        "name": player.name,
+        "level": player.level,
+        "xp": player.xp,
+        "stats": {
+            "strength_mod": player.strength_mod,
+            "thaumaturgy_mod": player.thaumaturgy_mod,
+            "agility_mod": player.agility_mod,
+            "resilience_mod": player.resilience_mod,
+        },
+        "icon": player.icon,
+        "deck": [c.name for c in player.deck],
+        "unlocked_unique": [c.name for c in player.unlocked_unique_cards],
+    }
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def load_game(path: str = _SAVE_PATH) -> Character | None:
+    """Load and return a ``Character`` from ``path`` if it exists."""
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        data = json.load(f)
+    prog = CHARACTER_PROGRESSIONS.get(data.get("name"), _DEFAULT_PROGRESSION)
+    player = Character(
+        name=data.get("name", _DEFAULT_CHARACTER),
+        hp=prog["base_hp"],
+        mana=prog["base_mana"],
+        stamina=prog["base_stamina"],
+        progression=prog,
+        icon=data.get("icon", "@"),
+        items=[],
+    )
+    player.level = data.get("level", 1)
+    player.xp = data.get("xp", 0)
+    player.strength_mod = data.get("stats", {}).get("strength_mod", 0)
+    player.thaumaturgy_mod = data.get("stats", {}).get("thaumaturgy_mod", 0)
+    player.agility_mod = data.get("stats", {}).get("agility_mod", 0)
+    player.resilience_mod = data.get("stats", {}).get("resilience_mod", 0)
+
+    # reconstruct deck and unlocks
+    player.deck = [_CARD_LOOKUP[name] for name in data.get("deck", []) if name in _CARD_LOOKUP]
+    player.unlocked_unique_cards = [_CARD_LOOKUP[name] for name in data.get("unlocked_unique", []) if name in _CARD_LOOKUP]
+    return player

--- a/start_menu.py
+++ b/start_menu.py
@@ -1,9 +1,45 @@
+import os
 import tkinter as tk
+from tkinter import messagebox
 from ui.fullscreen import create_fullscreen_root
+from save_system import save_game, load_game
 
 
-def run_start_menu():
-    """Display a menu for choosing the game mode.
+def run_title_menu():
+    """Display the initial title screen with new/load/continue options."""
+    selection = {"mode": None, "player": None}
+
+    def choose_new():
+        selection["mode"] = "new"
+        root.quit()
+
+    def choose_load():
+        selection["mode"] = "load"
+        root.quit()
+
+    def choose_continue():
+        selection["mode"] = "continue"
+        root.quit()
+
+    root = create_fullscreen_root("Medieval Duel")
+    tk.Label(root, text="Medieval Duel", font=("Arial", 48)).pack(pady=40)
+
+    btn_opts = {"font": ("Arial", 24), "width": 15, "height": 2}
+
+    if os.path.exists("savegame.json"):
+        tk.Button(root, text="Continue", command=choose_continue, **btn_opts).pack(pady=10)
+
+    tk.Button(root, text="New Game", command=choose_new, **btn_opts).pack(pady=10)
+    tk.Button(root, text="Load Game", command=choose_load, **btn_opts).pack(pady=10)
+    tk.Button(root, text="Quit", command=root.quit, **btn_opts).pack(pady=10)
+
+    root.mainloop()
+    root.destroy()
+    return selection
+
+
+def run_start_menu(player=None):
+    """Display the in-game menu for selecting mode or saving/loading.
 
     Returns one of:
     ``"dungeon"`` for the dungeon crawler,
@@ -30,6 +66,22 @@ def run_start_menu():
         selection["mode"] = "library"
         root.quit()
 
+    def save():
+        if player is None:
+            messagebox.showinfo("Save", "No player data to save.")
+            return
+        save_game(player)
+        messagebox.showinfo("Save", "Game saved.")
+
+    def load():
+        loaded = load_game()
+        if loaded is None:
+            messagebox.showerror("Load", "No save file found.")
+            return
+        selection["mode"] = "loadgame"
+        selection["player"] = loaded
+        root.quit()
+
     def exit_game():
         root.quit()
 
@@ -42,6 +94,8 @@ def run_start_menu():
     tk.Button(root, text="Player Sheet", command=choose_deckbuilder, **btn_opts).pack(pady=10)
     tk.Button(root, text="Bestiary", command=choose_bestiary, **btn_opts).pack(pady=10)
     tk.Button(root, text="Card Library", command=choose_library, **btn_opts).pack(pady=10)
+    tk.Button(root, text="Save Game", command=save, **btn_opts).pack(pady=10)
+    tk.Button(root, text="Load Game", command=load, **btn_opts).pack(pady=10)
     tk.Button(root, text="Quit", command=exit_game, **btn_opts).pack(pady=10)
 
     root.mainloop()
@@ -50,8 +104,5 @@ def run_start_menu():
 
 
 if __name__ == "__main__":
-    mode = run_start_menu()
-    if mode:
-        print(f"Selected mode: {mode}")
-    else:
-        print("Quit from start menu")
+    result = run_title_menu()
+    print(result)


### PR DESCRIPTION
## Summary
- add `save_system` with basic JSON save/load
- expand start menu with title screen plus save/load controls
- update main entrypoint to use new menus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0fea643483238924551ba32841ff