### PR TITLE
Fix deck builder filtering and save/load unique cards

### DIFF
--- a/deck_builder.py
+++ b/deck_builder.py
@@ -136,6 +136,16 @@ def run_deck_builder_menu(player: Character):
     # Include any unique cards the player has unlocked
     card_prototypes.extend(player.unlocked_unique_cards)
 
+    # Filter out cards that the player cannot currently use
+    allowed_cards = []
+    for c in card_prototypes:
+        if level < getattr(c, "level_requirement", 1):
+            continue
+        if any(player.stat_mod(stat) < req for stat, req in getattr(c, "stat_requirements", {}).items()):
+            continue
+        allowed_cards.append(c)
+    card_prototypes = allowed_cards
+
     card_types = sorted({c.card_type for c in card_prototypes})
 
     root = create_fullscreen_root(f"Deck Builder - {player.name}")

--- a/player_sheet.py
+++ b/player_sheet.py
@@ -103,9 +103,12 @@ def run_player_sheet(player: Character | None = None) -> Character:
         frame = tk.Frame(root2)
         frame.pack(fill="both", expand=True)
         vars = []
-        cards = [c for c in player.unique_library if c not in player.unlocked_unique_cards]
-        if player.level == 1:
-            cards = [c for c in cards if c.cost <= 1 and c.resource_type in ("mana", "stamina")]
+        cards = [
+            c
+            for c in player.unique_library
+            if c not in player.unlocked_unique_cards
+            and player.level >= getattr(c, "level_requirement", 1)
+        ]
         for card in cards:
             var = tk.IntVar()
             chk = tk.Checkbutton(frame, text=f"{card.name} (cost {card.cost} {card.resource_type})", variable=var, anchor="w", justify="left")

--- a/save_system.py
+++ b/save_system.py
@@ -58,6 +58,12 @@ def load_game(path: str = _SAVE_PATH) -> Character | None:
         icon=data.get("icon", "@"),
         items=[],
     )
+    # Rebuild the unique card library for this character
+    if player.name in CHARACTER_CARDS:
+        player.unique_library = [
+            _make_card(info)
+            for info in CHARACTER_CARDS[player.name]["cards"]
+        ]
     player.level = data.get("level", 1)
     player.xp = data.get("xp", 0)
     player.strength_mod = data.get("stats", {}).get("strength_mod", 0)

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+import unittest
+from characters import Character
+from character_cards import CHARACTER_CARDS
+from deck_builder import _make_card
+from save_system import save_game, load_game
+
+class TestSaveLoad(unittest.TestCase):
+    def test_unique_library_persisted(self):
+        infos = CHARACTER_CARDS['Aurelia Flameheart']['cards']
+        library = [_make_card(i) for i in infos]
+        player = Character('Aurelia Flameheart', 10, 10, 10,
+                           unique_library=library)
+        player.unlocked_unique_cards = library[:2]
+        player.deck = library[:20]
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, 'save.json')
+            save_game(player, path)
+            loaded = load_game(path)
+            self.assertEqual(len(loaded.unique_library), len(library))
+            self.assertEqual(
+                {c.name for c in loaded.unlocked_unique_cards},
+                {c.name for c in player.unlocked_unique_cards}
+            )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- rebuild unique card pool when loading a save
- hide cards you can't use in the deck builder
- restrict unique unlocks to cards at or below your level
- test that saving/loading retains unique card data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1231a888832393c3041ada5b5e24